### PR TITLE
Use Semantic Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The [compiled artifact](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.ev
 <dependency>
     <groupId>com.evolvedbinary.cql</groupId>
     <artifactId>corpusql-parser</artifactId>
-    <version>1.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.evolvedbinary.cql</groupId>
     <artifactId>corpusql-parser</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>Corpus Query Language Parser</name>
     <description>A Parser for Corpus Query Language</description>


### PR DESCRIPTION
This PR depends on #35 
Switch to `1.1.0-SNAPSHOT` instead of `1.1-SNAPSHOT` which matches all the other version numbers we are using.